### PR TITLE
Allow for non-dict and non-list constants to not use K

### DIFF
--- a/jsonbender/core.py
+++ b/jsonbender/core.py
@@ -131,8 +131,10 @@ def bend(mapping, source):
                 raise BendingException(m)
         elif isinstance(value, list):
             newv = map(lambda v: bend(v, source), value)
-        else:
+        elif isinstance(value, dict):
             newv = bend(value, source)
+        else:
+            newv = value
         res[k] = newv
     return res
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,6 +62,11 @@ class TestBend(unittest.TestCase):
         source = {}
         self.assertRaises(BendingException, bend, mapping, source)
 
+    def test_constants_without_K(self):
+        mapping = {'a': 'a const value', 'b': 123}
+        self.assertDictEqual(bend(mapping, {}),
+                             {'a': 'a const value', 'b': 123})
+
 
 class TestOperators(unittest.TestCase):
     def test_add(self):


### PR DESCRIPTION
It is a common mistake to forget the `K` when adding a constant to the mapping. However, K is only needed to differentiate between constant dicts or lists and submappings, so if the value is not either a dict or a list, there's no need fo `K`.