### PR TITLE
Add contexts

### DIFF
--- a/jsonbender/core.py
+++ b/jsonbender/core.py
@@ -17,10 +17,16 @@ class Bender(object):
     """
 
     def __init__(self, *args, **kwargs):
-        raise NotImplementedError()
+        pass
 
     def __call__(self, source):
-        return self.execute(source)
+        return self.raw_execute(source)
+
+    def raw_execute(self, source):
+        if isinstance(source, Transport):
+            return Transport(self.execute(source.value), source.context)
+        else:
+            return self.execute(source)
 
     def execute(self, source):
         raise NotImplementedError()
@@ -60,7 +66,7 @@ class Compose(Bender):
         self._first = first
         self._second = second
 
-    def execute(self, source):
+    def raw_execute(self, source):
         return self._second(self._first(source))
 
 
@@ -108,11 +114,22 @@ class Div(BinaryOperator):
         return float(v1) / float(v2)
 
 
+class Context(Bender):
+    def raw_execute(self, source):
+        return Transport(source.context, source.context)
+
+
 class BendingException(Exception):
     pass
 
 
-def bend(mapping, source):
+class Transport(object):
+    def __init__(self, value, context):
+        self.value = value
+        self.context = context
+
+
+def bend(mapping, source, context=None):
     """
     The main bending function.
 
@@ -121,18 +138,24 @@ def bend(mapping, source):
 
     returns a new dict according to the provided map.
     """
+    context = {} if context is None else context
+    transport = Transport(source, context)
+    return _bend(mapping, transport)
+
+
+def _bend(mapping, transport):
     res = {}
     for k, value in iteritems(mapping):
         if isinstance(value, Bender):
             try:
-                newv = value(source)
+                newv = value(transport).value
             except Exception as e:
                 m = 'Error for key {}: {}'.format(k, str(e))
                 raise BendingException(m)
         elif isinstance(value, list):
-            newv = map(lambda v: bend(v, source), value)
+            newv = map(lambda v: _bend(v, transport), value)
         elif isinstance(value, dict):
-            newv = bend(value, source)
+            newv = _bend(value, transport)
         else:
             newv = value
         res[k] = newv

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 import unittest
 
-from jsonbender import bend, BendingException, S, K
+from jsonbender import S, K
+from jsonbender.core import bend, BendingException, Context
 
 
 class TestBend(unittest.TestCase):
@@ -66,6 +67,16 @@ class TestBend(unittest.TestCase):
         mapping = {'a': 'a const value', 'b': 123}
         self.assertDictEqual(bend(mapping, {}),
                              {'a': 'a const value', 'b': 123})
+
+    def test_context_shallow(self):
+        mapping = {'a': Context() >> S('b')}
+        res = bend(mapping, {}, context={'b': 23})
+        self.assertDictEqual(res, {'a': 23})
+
+    def test_context_deep(self):
+        mapping = {'a': [{'a': Context() >> S('b')}]}
+        res = bend(mapping, {}, context={'b': 23})
+        self.assertDictEqual(res, {'a': [{'a': 23}]})
 
 
 class TestOperators(unittest.TestCase):


### PR DESCRIPTION
Sometimes it is necessary to get a value from somewhere other than the input dict, that's what the `Context()` bender and the `context` arg to `bender()` are for.