### PR TITLE
feat/Support Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 dist/
 MANIFEST
 *.egg-info
+.tox

--- a/jsonbender/core.py
+++ b/jsonbender/core.py
@@ -39,6 +39,12 @@ class Bender(object):
     def __div__(self, other):
         return Div(self, other)
 
+    def __truediv__(self, other):
+        return Div(self, other)
+
+    def __floordiv__(self, other):
+        return Div(self, other)
+
     def __rshift__(self, other):
         return Compose(self, other)
 
@@ -160,7 +166,7 @@ def _bend(mapping, transport):
                 m = 'Error for key {}: {}'.format(k, str(e))
                 raise BendingException(m)
         elif isinstance(value, list):
-            newv = map(lambda v: _bend(v, transport), value)
+            newv = list(map(lambda v: _bend(v, transport), value))
         elif isinstance(value, dict):
             newv = _bend(value, transport)
         else:

--- a/jsonbender/list_ops.py
+++ b/jsonbender/list_ops.py
@@ -50,7 +50,9 @@ class Forall(ListOp):
     Forall(lambda i: i * 2)(range(5))  # -> [0, 2, 4, 6, 8]
     ```
     """
-    op = map
+
+    def op(self, func, vals):
+        return list(map(func, vals))
 
     @classmethod
     def bend(cls, mapping, context=None):
@@ -118,7 +120,7 @@ class Reduce(ListOp):
         try:
             return reduce(func, vals)
         except TypeError as e:  # empty list with no initial value
-            raise ValueError(e.message)
+            raise ValueError(e.args[0])
 
 
 class Filter(ListOp):
@@ -132,7 +134,9 @@ class Filter(ListOp):
     Filter(lambda i: i % 2 == 0)(range(5))  # -> [0, 2, 4]
     ```
     """
-    op = filter
+
+    def op(self, func, vals):
+        return list(filter(func, vals))
 
 
 class FlatForall(ListOp):

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,11 @@ setup(
     download_url='https://codeload.github.com/Onyo/jsonbender/tar.gz/' + __version__,
     keywords=['dsl', 'edsl', 'json'],
     packages=['jsonbender'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
+    ],
 )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,7 @@
 import unittest
 
+import sys
+
 from jsonbender import S, K
 from jsonbender.core import bend, BendingException, Context, BinaryOperator
 from jsonbender.test import BenderTestMixin
@@ -105,7 +107,11 @@ class TestOperators(unittest.TestCase, BenderTestMixin):
 class TestGetItem(unittest.TestCase, BenderTestMixin):
     def test_getitem(self):
         bender = S('val')[2:8:2]
-        self.assert_bender(bender, {'val': range(10)}, [2, 4, 6])
+        if sys.version_info.major == 2:
+            val = range(10)
+        else:
+            val = list(range(10))
+        self.assert_bender(bender, {'val': val}, [2, 4, 6])
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[testenv]
+deps=
+    unittest2
+    discover
+commands=unit2 discover tests -v
+
+[tox]
+envlist =
+    py{27,35}-app


### PR DESCRIPTION
* Support python3
* Add tox to run unit tests

Only a few changes were needed. The biggest one was that builtins like `map` and `filter` don't return lists anymore they return iterators. I've explicitly consumed the iterators using `list()` to maintain the behaviour of jsonbender.

@etandel Can you review and merge?