### PR TITLE
Avoid iterables as default argument

### DIFF
--- a/jsonbender/selectors.py
+++ b/jsonbender/selectors.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from jsonbender.core import Bender
 
 
@@ -6,7 +8,12 @@ class K(Bender):
     Selects a constant value.
     """
     def __init__(self, value):
-        self._val = value
+        try:
+            iter(value)
+        except TypeError:
+            self._val = value
+        else:
+            self._val = deepcopy(value)
 
     def execute(self, source):
         return self._val

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -11,6 +11,14 @@ class TestK(unittest.TestCase, BenderTestMixin):
         self.assert_bender(K(1), {}, 1)
         self.assert_bender(K('string'), {}, 'string')
 
+    def test_k_list_constructor(self):
+        sample_list = []
+        k = K(sample_list)
+
+        sample_list.append(1)
+        self.assertListEqual(sample_list, [1])
+        self.assertListEqual(k.execute('a'), [])
+
 
 class STestsMixin(BenderTestMixin):
     def test_no_selector_raises_value_error(self):


### PR DESCRIPTION
Using the library I found out the programmer might get caught in a bug when dealing with `K(<iterable>)` such as `K([])`. In order to avoid that, I have created a safe check in the constructor.