### PR TITLE
[fix: #31 ] enable Context() in control flows

### DIFF
--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -31,6 +31,11 @@ class TestIf(BenderTestMixin, unittest.TestCase):
         if_ = If(S('country') == K('China'), S('first_name'))
         self.assert_bender(if_, self.guga, None)
 
+    def test_if_context(self):
+        ctx = { 'key': True }
+        if_ = If((Context() >> S('key')), S('first_name'))
+        self.assert_bender(if_, self.na_li, 'Li', context=ctx)
+
 
 class TestAlternation(BenderTestMixin, unittest.TestCase):
     def test_empty_benders(self):


### PR DESCRIPTION
This is a fix for issue #31  - In Control flows we are not able to use `Context()`

The root cause is that we are currently initialising the `Transport` object for the `Context()` with an empty dictionary because the source is not given.

I replaced the `execute` method of the flow methods to `raw_execute`.  In the overwritten `raw_executes` we create a new `Transport` object from the source and pass it to the `Bender` objects. This way the `Context` objects will get this source `Transport` object and will use it to create their own.

